### PR TITLE
fix: correct the spelling of qeemat

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         </div> 
         <div class="details typewriter">
             <a href="https://twitter.com/atbrakhi" target="_blank">
-                <h1>Keemat samjho saahab </h1>
+                <h1>Qeemat samjho saahab </h1>
             </a>
         </div>
     </body>


### PR DESCRIPTION
In Urdu language there is no word such as keemat. It should ideally be qeemat which is pronounced from the epiglottis. If we write it in Devnaagri script it includes a Nuqta to emphasize the same. Correct me if I'm wrong